### PR TITLE
Emit pollSuccess when poll succeeds

### DIFF
--- a/lib/polling.js
+++ b/lib/polling.js
@@ -11,10 +11,10 @@ TradeOfferManager.prototype.doPoll = function() {
 		this._resetPollTimer(Date.now() - this._lastPoll);
 		return;
 	}
-	
+
 	this._lastPoll = Date.now();
 	clearTimeout(this._pollTimer);
-	
+
 	this.emit('debug', 'Doing trade offer poll since ' + this.pollData.offersSince);
 	this.getOffers(EOfferFilter.ActiveOnly, new Date(this.pollData.offersSince ? (this.pollData.offersSince * 1000) : 0), function(err, sent, received) {
 		if(err) {
@@ -25,9 +25,9 @@ TradeOfferManager.prototype.doPoll = function() {
 		}
 
 		var origPollData = clone(this.pollData);
-		
+
 		var offers = this.pollData.sent || {};
-		
+
 		sent.forEach(function(offer) {
 			if(offers[offer.id] && offer.state != offers[offer.id]) {
 				this.emit('sentOfferChanged', offer, offers[offer.id]);
@@ -39,25 +39,25 @@ TradeOfferManager.prototype.doPoll = function() {
 					}
 				}.bind(this));
 			}
-			
+
 			offers[offer.id] = offer.state;
 		}.bind(this));
-		
+
 		this.pollData.sent = offers;
 		offers = this.pollData.received || {};
-		
+
 		received.forEach(function(offer) {
 			if(!offers[offer.id] && offer.state == ETradeOfferState.Active) {
 				this.emit('newOffer', offer);
 			} else if(offers[offer.id] && offer.state != offers[offer.id]) {
 				this.emit('receivedOfferChanged', offer, offers[offer.id]);
 			}
-			
+
 			offers[offer.id] = offer.state;
 		}.bind(this));
-		
+
 		this.pollData.received = offers;
-		
+
 		// Find the latest update time
 		var latest = this.pollData.offersSince || 0;
 		sent.concat(received).forEach(function(offer) {
@@ -66,9 +66,9 @@ TradeOfferManager.prototype.doPoll = function() {
 				latest = updated;
 			}
 		});
-		
+
 		this.pollData.offersSince = latest;
-		
+
 		// Check if any offers which we want to accept are still Active
 		if(this.pollData.toAccept) {
 			var offer, offerID, lastAttempt;
@@ -76,13 +76,13 @@ TradeOfferManager.prototype.doPoll = function() {
 				offer = received.filter(function(item) {
 					return item.id == offerID;
 				});
-				
+
 				if(!offer[0] || offer[0].state != ETradeOfferState.Active) {
 					// It's no longer active, so we're done here
 					delete this.pollData.toAccept[offerID];
 					continue;
 				}
-				
+
 				if(Date.now() - this.pollData.toAccept[offerID] > 60000) {
 					// We last tried to accept this offer over a minute ago. Try again.
 					this.pollData.toAccept[offerID] = Date.now();
@@ -91,11 +91,13 @@ TradeOfferManager.prototype.doPoll = function() {
 			}
 		}
 
+		this.emit('pollSuccess');
+
 		// If something has changed, emit the event
 		if(!deepEqual(origPollData, this.pollData)) {
 			this.emit('pollData', this.pollData);
 		}
-		
+
 		this._resetPollTimer();
 	}.bind(this));
 };


### PR DESCRIPTION
pollData only gets emitted whenever the data changed, this helps with the detection of steam issues. Sorry for all the -'d indentions, i have this as a default setting in sublime :^)