### PR TITLE
Fix the check to see if an item is already in a trade

### DIFF
--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -320,7 +320,7 @@ function addItem(details, offer, list) {
 		throw new Error("Missing appid, contextid, or assetid parameter");
 	}
 	
-	if(list.some(function(tradeItem) { itemEquals(tradeItem, item); })) {
+	if(list.some(function(tradeItem) { return itemEquals(tradeItem, item); })) {
 		// Already in trade
 		return;
 	}


### PR DESCRIPTION
We should be returning the output of `itemEquals()`, as just calling the function won't do us any good.