### PR TITLE
fix(polling): fix mem leak caused by polling

### DIFF
--- a/lib/polling.js
+++ b/lib/polling.js
@@ -49,6 +49,24 @@ TradeOfferManager.prototype.doPoll = function() {
 		}
 
 		var origPollData = clone(this.pollData);
+
+		var trackedIds = sent.map(function(offer) {
+			return offer.id
+		});
+		
+		trackedIds = trackedIds.concat(received.map(function(offer) {
+			return offer.id
+		}));
+
+		var oldIds = Object.keys(this.pollData.sent || {});
+		oldIds = oldIds.concat(Object.keys(this.pollData.received || {}));
+
+		for (var i = 0; i < oldIds.length; i++) {
+			if (trackedIds.indexOf(oldIds[i]) === -1) {
+				delete this.pollData.sent[oldIds[i]];
+				delete this.pollData.received[oldIds[i]];
+			}
+		}
 		
 		var offers = this.pollData.sent || {};
 		


### PR DESCRIPTION
Turns out there's actually a pretty big memory leak caused by this, as the list of offers will expand infinitely until it is restarted. 

With ~40 bots running on one machine, this ate 6 gigs of memory in 7 hours. Granted, those numbers depend  heavily on the amount of trades those bots are doing at the time.

I checked throughout the repo before making this change to make sure this wouldn't affect anything, but I can't be 100% sure. I've been running this code in production for around a day now with no issues, but that doesn't mean this won't cause issues with anyone else's use case.

The basic idea should be pretty self explanatory, but to clarify, the thinking is that since we won't get updates for trades which have passed the modified date anymore and are no longer active, its safe to remove them from the poll data. This should limit the poll data size of sent and received to 500 keys. 