### PR TITLE
Forced appid to be a number

### DIFF
--- a/lib/classes/EconItem.js
+++ b/lib/classes/EconItem.js
@@ -14,6 +14,7 @@ function EconItem(item) {
 		this.currencyid = this.currencyid.toString();
 	}
 
+	this.appid = this.appid ? parseInt(this.appid, 10) : 0;
 	this.classid = this.classid.toString();
 	this.instanceid = (this.instanceid || 0).toString();
 	this.amount = this.amount ? parseInt(this.amount, 10) : 1;


### PR DESCRIPTION
It's annoying to see it once as a number, once a string. 
The change **may** affect some comparisons (identities) in the module or users' code...