### PR TITLE
Don't acknowledge offer change if unknown or glitched

### DIFF
--- a/lib/polling.js
+++ b/lib/polling.js
@@ -83,6 +83,8 @@ TradeOfferManager.prototype.doPoll = function() {
 				// We sent this offer, and it has now changed state
 				this.emit('sentOfferChanged', offer, offers[offer.id]);
 				offers[offer.id] = offer.state;
+			} else {
+				offers[offer.id] = offer.state;
 			}
 
 			if(offer.state == ETradeOfferState.Active) {
@@ -121,8 +123,6 @@ TradeOfferManager.prototype.doPoll = function() {
 					}.bind(this));
 				}
 			}
-			
-			offers[offer.id] = offer.state;
 		}.bind(this));
 
 		if(this.cancelOfferCount) {

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -79,11 +79,9 @@ TradeOfferManager.prototype.doPoll = function() {
 					this.emit('unknownOfferSent', offer);
 					offers[offer.id] = offer.state;
 				}
-			} else if(!offer._isGlitched() && offers[offer.id] && offer.state != offers[offer.id]) {
+			} else if(!offer._isGlitched() && offer.state != offers[offer.id]) {
 				// We sent this offer, and it has now changed state
 				this.emit('sentOfferChanged', offer, offers[offer.id]);
-				offers[offer.id] = offer.state;
-			} else {
 				offers[offer.id] = offer.state;
 			}
 


### PR DESCRIPTION
Unknown offers will not emit "unknownOfferSent" because saved offer state will be set even if delay is not met.

Glitched offers will not emit "sentOfferChanged" because saved offer state is updated before another poll.