### PR TITLE
Adding pollData to constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ function TradeOfferManager(options) {
 	this.cancelOfferCount = options.cancelOfferCount;
 	this.cancelOfferCountMinAge = options.cancelOfferCountMinAge || 0;
 
-	this.pollData = {};
+	this.pollData = options.pollData || {};
 	this.apiKey = null;
 	this.steamID = null;
 	


### PR DESCRIPTION
Is there any reason that the constructor does not accept `pollData` property. It sets it to `{}`. From what I can tell it needs to be set as a property quite quickly before the pollInterval is triggered. Typically this is not an issue. I would just find it slightly cleaner to pass the `pollData` in the constructor. 

If it works, here is the PR for the change. If not please reject and I am happy to adjust.

Can't add PR for Wiki :)