### PR TITLE
Fix reference self to this

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -59,7 +59,7 @@ TradeOfferManager.prototype._hasDescription = function(item, appid) {
 };
 
 TradeOfferManager.prototype._addDescriptions = function(items, callback) {
-	var descriptionRequired = items.filter(item => !self._hasDescription(item));
+	var descriptionRequired = items.filter(item => !this._hasDescription(item));
 
 	if (descriptionRequired.length == 0) {
 		callback(null, this._mapItemsToDescriptions(null, null, items));


### PR DESCRIPTION
self isn't declared and should be replace with this.

var descriptionRequired = items.filter(item => !self._hasDescription(item));
	                                                ^
ReferenceError: self is not defined
    at node_modules\steam-tradeoffer-manager\lib\assets.js:62:50
    at Array.filter (native)
    at TradeOfferManager._digestDescriptions.TradeOfferManager._mapItemsToDescriptions.TradeOfferManager._addDescriptions.descriptionRequired [as _addDescriptions] (node_modules\steam-tradeoffer-manager\lib\assets.js:62:34)