### PR TITLE
Added option 'dontUpdateState' for TradeOffer.accept

### DIFF
--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -578,8 +578,15 @@ TradeOffer.prototype.cancel = TradeOffer.prototype.decline = function(callback) 
 	});
 };
 
-TradeOffer.prototype.accept = function(callback, options) {
-	options = options || {};
+TradeOffer.prototype.accept = function(dontUpdateState, callback) {
+	if (typeof dontUpdateState == 'undefined') {
+		dontUpdateState = false;
+	}
+	
+	if (typeof dontUpdateState == 'function') {
+		callback = dontUpdateState;
+		dontUpdateState = false;
+	}
 	
 	if (!this.id) {
 		Helpers.makeAnError(new Error("Cannot accept an unsent offer"), callback);
@@ -638,7 +645,7 @@ TradeOffer.prototype.accept = function(callback, options) {
 			return;
 		}
 		
-		if (options.dontUpdateState) {
+		if (dontUpdateState) {
 			callback(null, body);
 			return;
 		}

--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -578,14 +578,14 @@ TradeOffer.prototype.cancel = TradeOffer.prototype.decline = function(callback) 
 	});
 };
 
-TradeOffer.prototype.accept = function(updateState, callback) {
-	if (typeof updateState == 'undefined') {
-		updateState = true;
+TradeOffer.prototype.accept = function(skipStateUpdate, callback) {
+	if (typeof skipStateUpdate == 'undefined') {
+		skipStateUpdate = false;
 	}
 	
-	if (typeof updateState == 'function') {
-		callback = updateState;
-		updateState = true;
+	if (typeof skipStateUpdate == 'function') {
+		callback = skipStateUpdate;
+		skipStateUpdate = false;
 	}
 	
 	if (!this.id) {
@@ -645,7 +645,7 @@ TradeOffer.prototype.accept = function(updateState, callback) {
 			return;
 		}
 		
-		if (!updateState) {
+		if (skipStateUpdate) {
 			if (body.needs_mobile_confirmation || body.needs_email_confirmation) {
 				callback(null, 'pending');
 			} else {
@@ -653,6 +653,7 @@ TradeOffer.prototype.accept = function(updateState, callback) {
 			}
 			return;
 		}
+		
 
 		this.update((err) => {
 			if (err) {

--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -578,14 +578,14 @@ TradeOffer.prototype.cancel = TradeOffer.prototype.decline = function(callback) 
 	});
 };
 
-TradeOffer.prototype.accept = function(dontUpdateState, callback) {
-	if (typeof dontUpdateState == 'undefined') {
-		dontUpdateState = false;
+TradeOffer.prototype.accept = function(updateState, callback) {
+	if (typeof updateState == 'undefined') {
+		updateState = true;
 	}
 	
-	if (typeof dontUpdateState == 'function') {
-		callback = dontUpdateState;
-		dontUpdateState = false;
+	if (typeof updateState == 'function') {
+		callback = updateState;
+		updateState = true;
 	}
 	
 	if (!this.id) {
@@ -645,7 +645,7 @@ TradeOffer.prototype.accept = function(dontUpdateState, callback) {
 			return;
 		}
 		
-		if (dontUpdateState) {
+		if (!updateState) {
 			callback(null, body);
 			return;
 		}

--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -639,7 +639,7 @@ TradeOffer.prototype.accept = function(callback, options) {
 		}
 		
 		if (options.dontUpdateState) {
-			callback(null, 'accepted');
+			callback(null, body);
 			return;
 		}
 

--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -578,7 +578,9 @@ TradeOffer.prototype.cancel = TradeOffer.prototype.decline = function(callback) 
 	});
 };
 
-TradeOffer.prototype.accept = function(callback) {
+TradeOffer.prototype.accept = function(callback, options) {
+	options = options || {};
+	
 	if (!this.id) {
 		Helpers.makeAnError(new Error("Cannot accept an unsent offer"), callback);
 		return;
@@ -633,6 +635,11 @@ TradeOffer.prototype.accept = function(callback) {
 		this.manager.doPoll();
 
 		if (!callback) {
+			return;
+		}
+		
+		if (options.dontUpdateState) {
+			callback(null, 'accepted');
 			return;
 		}
 

--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -646,7 +646,11 @@ TradeOffer.prototype.accept = function(updateState, callback) {
 		}
 		
 		if (!updateState) {
-			callback(null, body);
+			if (body.needs_mobile_confirmation || body.needs_email_confirmation) {
+				callback(null, 'pending');
+			} else {
+				callback(null, 'accepted');
+			}
 			return;
 		}
 


### PR DESCRIPTION
Now you can disable updating state of the offer after accepting.
I need this option because my bot accepting many offers per day and sometimes i get `Data temporarily unavailable` on accepting BUT offer is already accepted and this cause problems with users of my website. With this option i can disable `getOffer` after accepting offer, but i can be sure that this offer is accepted.
(like in [node-steam-tradeoffers](https://github.com/Alex7Kom/node-steam-tradeoffers/blob/master/index.js#L249))
