### PR TITLE
Added simple way to do full update poll on demand

### DIFF
--- a/lib/polling.js
+++ b/lib/polling.js
@@ -18,7 +18,7 @@ var clone = require('clone');
  *      - `pendingCancelTime` - Ditto `cancelTime`, except only for offers which are CreatedNeedsConfirmation.
  */
 
-TradeOfferManager.prototype.doPoll = function() {
+TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 	if (this.hasShutDown) {
 		// In case a race condition causes this to be called after we've shutdown
 		return;
@@ -42,7 +42,7 @@ TradeOfferManager.prototype.doPoll = function() {
 	}
 
 	var fullUpdate = false;
-	if (Date.now() - this._lastPollFullUpdate >= 120000) {
+	if (Date.now() - this._lastPollFullUpdate >= 120000 || doFullUpdate) {
 		fullUpdate = true;
 		this._lastPollFullUpdate = Date.now();
 		offersSince = 1;


### PR DESCRIPTION
As the title says. It would seem that sometimes Steam gets 'backed up', and I get emitted events only when a full poll happens, so a manual full poll is sometimes useful instead of waiting for another two-minute mark.