### PR TITLE
Return whole offerData if no arguments are passed to data method

### DIFF
--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -263,7 +263,16 @@ TradeOffer.prototype.containsItem = function(item) {
 TradeOffer.prototype.data = function(key, value) {
 	var pollData = this.manager.pollData;
 
-	if (arguments.length < 2) {
+	if (arguments.length < 1) {
+		// No arguments passed, so we return the whole offerData of this offer
+		if (!this.id){
+			// Offer isn't sent yet, return object cache
+			return this._tempData;
+		}
+
+		// return offerData from pollData if it exists, else return an empty object
+		return (pollData.offerData && pollData.offerData[this.id]) || {};
+	} else if (arguments.length < 2) {
 		// We're only retrieving the value.
 		if (!this.id) {
 			// Offer isn't sent yet, return from object cache


### PR DESCRIPTION
I think it would be handy if there was a easy way to get the whole offerData object of a TradeOffer.

Since we are using the `data` method to access the properties of the offerData object, I implemented this functionality into the `data` method when **no arguments** are passed.

This should be backwards compatible, since it was impossible before to access the data method with zero arguments.