### PR TITLE
Fire "accept" callback with error when web session expires

### DIFF
--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -653,7 +653,7 @@ TradeOffer.prototype.accept = function(skipStateUpdate, callback) {
 		if (err || response.statusCode != 200) {
 			if (response && response.statusCode == 403) {
 				this.manager._community._notifySessionExpired(new Error("HTTP error 403"));
-				Helpers.makeAnError(new Error("Not Logged In"));
+				Helpers.makeAnError(new Error("Not Logged In"), callback, body);
 			} else {
 				Helpers.makeAnError(err || new Error("HTTP error " + response.statusCode), callback, body);
 			}


### PR DESCRIPTION
When accepting an incoming trade offer, if the steam-community web session is expired, the callback does not fire with an error. This does not allow for cleanup when it occurs. This change fires the callback with the "Not Logged In" error.