### PR TITLE
Fixed doPoll() spam calls at the start

### DIFF
--- a/lib/polling.js
+++ b/lib/polling.js
@@ -23,7 +23,13 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 		return;
 	}
 
-	if (!this.apiKey || Date.now() - this._lastPoll < 1000) {
+	if(!this.apiKey){
+		this.emit('debug', 'No API Key, shouldn\'t poll' );
+		this._resetPollTimer(1000);
+		return;
+	}
+	else if (this._lastPoll !== 0 && Date.now() - this._lastPoll < 1000) {
+		this.emit('debug', '# Seconds Since Last Poll ' + (Date.now() - this._lastPoll)/1000 );
 		// Either we don't have an API key, or we last polled less than a second ago... we shouldn't spam the API
 		// Reset the timer to poll one second after the last one
 		this._resetPollTimer(Date.now() - this._lastPoll);


### PR DESCRIPTION
At the start of TradeOfferManager because of apiKey and the lastPoll default values, doPoll() was not being rate limited as it should.