### PR TITLE
Alternate fix for doPoll timer spam at startup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,10 +83,6 @@ function TradeOfferManager(options) {
 }
 
 TradeOfferManager.prototype.setCookies = function(cookies, familyViewPin, callback) {
-	if (this.hasShutDown) {
-		delete this.hasShutDown;
-	}
-
 	if (typeof familyViewPin === 'function') {
 		callback = familyViewPin;
 		familyViewPin = null;
@@ -101,9 +97,8 @@ TradeOfferManager.prototype.setCookies = function(cookies, familyViewPin, callba
 				this._community.setCookies(['Steam_Language=' + this._languageName]);
 			}
 
-			if (!this._pollTimer && this.pollInterval >= 1000) {
-				this.doPoll();
-			}
+			clearTimeout(this._pollTimer);
+			this.doPoll();
 		}
 
 		if (callback) {
@@ -131,7 +126,6 @@ TradeOfferManager.prototype.shutdown = function() {
 	this._community = new SteamCommunity();
 	this._steam = null;
 	this.apiKey = null;
-	this.hasShutDown = true;
 };
 
 TradeOfferManager.prototype.parentalUnlock = function(pin, callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -200,7 +200,7 @@ TradeOfferManager.prototype.loadInventory = function(appid, contextid, tradableO
 /**
  * Get the contents of a user's specific inventory context.
  * @deprecated Use getUserInventoryContents instead
- * @property {SteamID|string} sid - The user's SteamID as a SteamID object or a string which can parse into one
+ * @param {SteamID|string} sid - The user's SteamID as a SteamID object or a string which can parse into one
  * @param {int} appid - The Steam application ID of the game for which you want an inventory
  * @param {int} contextid - The ID of the "context" within the game you want to retrieve
  * @param {boolean} tradableOnly - true to get only tradable items and currencies

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -20,18 +20,17 @@ const minimumPollInterval = 1000;
  */
 
 TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
-	if (this.hasShutDown) {
-		// In case a race condition causes this to be called after we've shutdown
+	if (!this.apiKey) {
+		// In case a race condition causes this to be called after we've shutdown or before we have an API key
 		return;
 	}
 
 	const timeSinceLastPoll = Date.now() - this._lastPoll;
 
-	if (!this.apiKey || timeSinceLastPoll < minimumPollInterval) {
-		// Either we don't have an API key, or we last polled less than a second ago... we shouldn't spam the API
-		// Reset the timer to poll one second after the last one
-		const timeToNextPoll = minimumPollInterval - timeSinceLastPoll;
-		this._resetPollTimer(this.apiKey ? timeToNextPoll : minimumPollInterval);
+	if (timeSinceLastPoll < minimumPollInterval) {
+		// We last polled less than a second ago... we shouldn't spam the API
+		// Reset the timer to poll minimumPollInterval after the last one
+		this._resetPollTimer(minimumPollInterval - timeSinceLastPoll);
 		return;
 	}
 
@@ -274,7 +273,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 };
 
 TradeOfferManager.prototype._resetPollTimer = function(time) {
-	if (time || this.pollInterval >= 1000) {
+	if (time || this.pollInterval >= minimumPollInterval) {
 		clearTimeout(this._pollTimer);
 		this._pollTimer = setTimeout(this.doPoll.bind(this), time || this.pollInterval);
 	}

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -6,6 +6,8 @@ const EOfferFilter = TradeOfferManager.EOfferFilter;
 const EConfirmationMethod = TradeOfferManager.EConfirmationMethod;
 const deepEqual = require('deep-equal');
 
+const minimumPollInterval = 1000;
+
 /*
  * pollData is an object which has the following structure:
  *  - `offersSince` is the STANDARD unix time (Math.floor(Date.now() / 1000)) of the last known offer change
@@ -23,10 +25,13 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 		return;
 	}
 
-	if (!this.apiKey || Date.now() - this._lastPoll < 1000) {
+	const timeSinceLastPoll = Date.now() - this._lastPoll;
+
+	if (!this.apiKey || timeSinceLastPoll < minimumPollInterval) {
 		// Either we don't have an API key, or we last polled less than a second ago... we shouldn't spam the API
 		// Reset the timer to poll one second after the last one
-		this._resetPollTimer(Date.now() - this._lastPoll);
+		const timeToNextPoll = minimumPollInterval - timeSinceLastPoll;
+		this._resetPollTimer(this.apiKey ? timeToNextPoll : minimumPollInterval);
 		return;
 	}
 


### PR DESCRIPTION
Polling requires an API key so there's no point running it without one. The
function that obtains said key ensures polling is started, so any other attempt
at polling without a key (such as a tradeOffers or newItems event at startup)
can be safely treated as a race condition and ignored. This re-uses the shutdown
race condition bailout by simply treating the "key not yet set" state the same
as the "key no longer set" state.

Fixes #236 #237.