### PR TITLE
Trade offer "version"

### DIFF
--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -294,7 +294,7 @@ TradeOffer.prototype.send = function(callback) {
 
 	var offerdata = {
 		"newversion": true,
-		"version": 4,
+		"version": this.itemsToGive.length + this.itemsToReceive.length + 1,
 		"me": {
 			"assets": this.itemsToGive.map(itemMapper),
 			"currency": [], // TODO


### PR DESCRIPTION
Correct unnatural behavior of the script.
In the original steam exchanges, each time you add / remove an item from the exchange, the increment of the variable "version". I think it's worth to disguise itself under the original request

Screenshots from the original trades in STEAM
https://i.imgur.com/91ZYcMX.png
https://i.imgur.com/uvNlBXm.png
https://i.imgur.com/dS57czB.png