### PR TITLE
Remove deep equal

### DIFF
--- a/lib/polling.js
+++ b/lib/polling.js
@@ -4,7 +4,6 @@ const TradeOfferManager = require('./index.js');
 const ETradeOfferState = TradeOfferManager.ETradeOfferState;
 const EOfferFilter = TradeOfferManager.EOfferFilter;
 const EConfirmationMethod = TradeOfferManager.EConfirmationMethod;
-const deepEqual = require('deep-equal');
 
 const minimumPollInterval = 1000;
 
@@ -60,8 +59,6 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 			return;
 		}
 
-		var origPollData = JSON.parse(JSON.stringify(this.pollData)); // deep clone
-
 		/*if (fullUpdate) {
 			// We can only purge stuff if this is a full update; otherwise, lack of an offer's presence doesn't mean Steam forgot about it
 			var trackedIds = sent.map(offerId).concat(received.map(offerId)); // OfferIDs that are active in Steam's memory
@@ -108,6 +105,8 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 			});
 		}*/
 
+		let changed = false;
+		
 		var timestamps = this.pollData.timestamps || {};
 		var offers = this.pollData.sent || {};
 		var hasGlitchedOffer = false;
@@ -132,8 +131,10 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 					this.emit('unknownOfferSent', offer);
 					offers[offer.id] = offer.state;
 					timestamps[offer.id] = offer.created.getTime() / 1000;
+					changed = true;
 				}
 			} else if (offer.state != offers[offer.id]) {
+				changed = true;
 				if (!offer.isGlitched()) {
 					// We sent this offer, and it has now changed state
 					if (offer.fromRealTimeTrade && offer.state == ETradeOfferState.Accepted) {
@@ -162,6 +163,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 				}
 
 				if (cancelTime && (Date.now() - offer.updated.getTime() >= cancelTime)) {
+					changed = true;
 					offer.cancel((err) => {
 						if (!err) {
 							this.emit('sentOfferCanceled', offer, 'cancelTime');
@@ -182,6 +184,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 				}
 
 				if (pendingCancelTime && (Date.now() - offer.created.getTime() >= pendingCancelTime)) {
+					changed = true;
 					offer.cancel((err) => {
 						if (!err) {
 							this.emit('sentPendingOfferCanceled', offer);
@@ -208,6 +211,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 
 				// Make sure it's old enough
 				if (Date.now() - oldest.updated.getTime() >= this.cancelOfferCountMinAge) {
+					changed = true;
 					oldest.cancel((err) => {
 						if (!err) {
 							this.emit('sentOfferCanceled', oldest, 'cancelOfferCount');
@@ -225,7 +229,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 				hasGlitchedOffer = true;
 				return;
 			}
-
+			changed = true;
 			if (offer.fromRealTimeTrade) {
 				// This is a real-time trade offer
 				if (!offers[offer.id] && (offer.state == ETradeOfferState.CreatedNeedsConfirmation || (offer.state == ETradeOfferState.Active && offer.confirmationMethod != EConfirmationMethod.None))) {
@@ -264,7 +268,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 		this.emit('pollSuccess');
 
 		// If something has changed, emit the event
-		if (!deepEqual(origPollData, this.pollData)) {
+		if (changed) {
 			this.emit('pollData', this.pollData);
 		}
 


### PR DESCRIPTION
Removed deep equal, as it is unneccessary - Instead just set variable every time we changed something and check it at the end.
Reason for this is performance - deep-equal is computationaly expensive recursive function, so this decreases resource usage and speeds up event loop.