### PR TITLE
Use community for cancel tradeoffers instead of API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Steam Trade Offer Manager for Node.js
-[![npm version](https://img.shields.io/npm/v/steam-tradeoffer-manager.svg)](https://npmjs.com/package/steam-tradeoffer-manager)
-[![npm downloads](https://img.shields.io/npm/dm/steam-tradeoffer-manager.svg)](https://npmjs.com/package/steam-tradeoffer-manager)
-[![dependencies](https://img.shields.io/david/DoctorMcKay/node-steam-tradeoffer-manager.svg)](https://david-dm.org/DoctorMcKay/node-steam-tradeoffer-manager)
-[![license](https://img.shields.io/npm/l/steam-tradeoffer-manager.svg)](https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/blob/master/LICENSE)
-[![paypal](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=N36YVAT42CZ4G&item_name=node%2dsteam%2dtradeoffer%2dmanager&currency_code=USD)
+[![npm version](https://img.shields.io/npm/v/@tf2autobot/tradeoffer-manager.svg)](https://npmjs.com/package/@tf2autobot/tradeoffer-manager)
+[![npm downloads](https://img.shields.io/npm/dm/@tf2autobot/tradeoffer-manager.svg)](https://npmjs.com/package/@tf2autobot/tradeoffer-manager)
+[![dependencies](https://img.shields.io/david/tf2autobot/node-steam-tradeoffer-manager.svg)](https://david-dm.org/tf2autobot/node-steam-tradeoffer-manager)
+[![license](https://img.shields.io/npm/l/@tf2autobot/tradeoffer-manager.svg)](https://github.com/tf2autobot/node-steam-tradeoffer-manager/blob/master/LICENSE)
 
 This module is designed to be a completely self-contained manager for
 [Steam trade offers](https://steamcommunity.com/my/tradeoffers).
@@ -13,14 +12,9 @@ your application.
 
 **You absolutely need Node.js v4.0.0 or later or this won't work.**
 
-Install it from [npm](https://www.npmjs.com/package/steam-tradeoffer-manager) or check out the
+Install it from [npm](https://www.npmjs.com/package/@tf2autobot/tradeoffer-manager) or check out the
 [wiki](https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/wiki) for documentation.
-
-**Have a question about the module or coding in general? *Do not create a GitHub issue.* GitHub issues are for feature
-requests and bug reports. Instead, post in the [dedicated forum](https://dev.doctormckay.com/forum/9-node-steam-tradeoffer-manager/).
-Such issues may be ignored!**
 
 # Support
 
-Report bugs on the [issue tracker](https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/issues) or ask questions
-on the [dedicated forum](https://dev.doctormckay.com/forum/9-node-steam-tradeoffer-manager/).
+Report bugs on the [issue tracker](https://github.com/TF2Autobot/node-steam-tradeoffer-manager/issues).

--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -420,12 +420,46 @@ TradeOffer.prototype.cancel = TradeOffer.prototype.decline = function(callback) 
 		return;
 	}
 
-	this.manager._apiCall('POST', this.isOurOffer ? 'CancelTradeOffer' : 'DeclineTradeOffer', 1, {"tradeofferid": this.id}, (err) => {
+	this.manager._community.httpRequestPost(`https://steamcommunity.com/tradeoffer/${this.id}/${this.isOurOffer ? 'cancel' : 'decline'}`, {
+		/*"headers": {
+			"referer": `https://steamcommunity.com/tradeoffer/${(this.id || 'new')}/?partner=${this.partner.accountid}` + (this._token ? "&token=" + this._token : '')
+		},*/ // check if referrer is needed
+		"json": true,
+		"form": {
+			"sessionid": this.manager._community.getSessionID()
+		},
+		"checkJsonError": false,
+		"checkHttpError": false // we'll check it ourself. Some trade offer errors return HTTP 500
+	}, (err, response, body) => {
 		if (err) {
 			Helpers.makeAnError(err, callback);
 			return;
 		}
+		
+		if (response.statusCode != 200) {
+			if (response.statusCode == 401) {
+				this.manager._community._notifySessionExpired(new Error("HTTP error 401"));
+				Helpers.makeAnError(new Error("Not Logged In"), callback);
+				return;
+			}
+			
+			Helpers.makeAnError(new Error("HTTP error " + response.statusCode), callback, body);
+			return;
+		}
 
+		if (!body) {
+			Helpers.makeAnError(new Error("Malformed JSON response"), callback);
+			return;
+		}
+
+		if (body && body.strError) {
+			Helpers.makeAnError(null, callback, body);
+			return;
+		}
+
+		if (body && body.tradeofferid !== this.id) {
+			Helpers.makeAnError("Wrong response", callback);
+		}
 		this.state = this.isOurOffer ? ETradeOfferState.Canceled : ETradeOfferState.Declined;
 		this.updated = new Date();
 
@@ -434,7 +468,7 @@ TradeOffer.prototype.cancel = TradeOffer.prototype.decline = function(callback) 
 		}
 
 		this.manager.doPoll();
-	});
+	}, "tradeoffermanager");
 };
 
 TradeOffer.prototype.accept = function(skipStateUpdate, callback) {

--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -316,7 +316,7 @@ TradeOffer.prototype.send = function(callback) {
 
 	this.manager._community.httpRequestPost('https://steamcommunity.com/tradeoffer/new/send', {
 		"headers": {
-			"referer": `https://steamcommunity.com/tradeoffer/${(this.id || 'new')}/?partner=${this.partner.accountid}` + (this._token ? "&token=" + this._token : '')
+			"referer": `https://steamcommunity.com/tradeoffer/new/?partner=${this.partner.accountid}` + (this._token ? "&token=" + this._token : '')
 		},
 		"json": true,
 		"form": {
@@ -333,19 +333,19 @@ TradeOffer.prototype.send = function(callback) {
 		"checkHttpError": false // we'll check it ourself. Some trade offer errors return HTTP 500
 	}, (err, response, body) => {
 		this.manager._pendingOfferSendResponses--;
-		
+
 		if (err) {
 			Helpers.makeAnError(err, callback);
 			return;
 		}
-		
+
 		if (response.statusCode != 200) {
 			if (response.statusCode == 401) {
 				this.manager._community._notifySessionExpired(new Error("HTTP error 401"));
 				Helpers.makeAnError(new Error("Not Logged In"), callback);
 				return;
 			}
-			
+
 			Helpers.makeAnError(new Error("HTTP error " + response.statusCode), callback, body);
 			return;
 		}
@@ -441,12 +441,12 @@ TradeOffer.prototype.accept = function(skipStateUpdate, callback) {
 	if (typeof skipStateUpdate === 'undefined') {
 		skipStateUpdate = false;
 	}
-	
+
 	if (typeof skipStateUpdate === 'function') {
 		callback = skipStateUpdate;
 		skipStateUpdate = false;
 	}
-	
+
 	if (!this.id) {
 		Helpers.makeAnError(new Error("Cannot accept an unsent offer"), callback);
 		return;
@@ -503,7 +503,7 @@ TradeOffer.prototype.accept = function(skipStateUpdate, callback) {
 		if (!callback) {
 			return;
 		}
-		
+
 		if (skipStateUpdate) {
 			if (body.tradeid) {
 				this.tradeID = body.tradeid;
@@ -516,7 +516,7 @@ TradeOffer.prototype.accept = function(skipStateUpdate, callback) {
 			}
 			return;
 		}
-		
+
 
 		this.update((err) => {
 			if (err) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -61,11 +61,11 @@ function offerSuperMalformed(offer) {
 
 function offerMalformed(offer) {
 	return offerSuperMalformed(offer) || ((offer.items_to_give || []).length == 0 && (offer.items_to_receive || []).length == 0);
-};
+}
 
 function processItems(items) {
 	return items.map(item => new EconItem(item));
-};
+}
 
 exports.offerSuperMalformed = offerSuperMalformed;
 exports.offerMalformed = offerMalformed;

--- a/lib/index.js
+++ b/lib/index.js
@@ -471,43 +471,65 @@ TradeOfferManager.prototype.getOffers = function(filter, historicalCutoff, callb
 		"language": this._language,
 		"active_only": (filter == EOfferFilter.ActiveOnly) ? 1 : 0,
 		"historical_only": (filter == EOfferFilter.HistoricalOnly) ? 1 : 0,
-		"time_historical_cutoff": Math.floor(historicalCutoff.getTime() / 1000)
+		"time_historical_cutoff": Math.floor(historicalCutoff.getTime() / 1000),
+		"cursor": 0
 	};
 
-	this._apiCall('GET', 'GetTradeOffers', 1, options, (err, body) => {
-		if (err) {
-			callback(err);
-			return;
-		}
+	var sentOffers = [];
+	var receivedOffers = [];
 
-		if (!body.response) {
-			callback(new Error("Malformed API response"));
-			return;
-		}
+	var request = () => {
+		this._apiCall('GET', 'GetTradeOffers', 1, options, (err, body) => {
+			if (err) {
+				callback(err);
+				return;
+			}
 
-		// Make sure at least some offers are well-formed. Apparently some offers can be empty just forever. Because Steam.
-		var allOffers = (body.response.trade_offers_sent || []).concat(body.response.trade_offers_received || []);
-		if (allOffers.length > 0 && (allOffers.every(Helpers.offerMalformed) || allOffers.some(Helpers.offerSuperMalformed))) {
-			callback(new Error("Data temporarily unavailable"));
-			return;
-		}
+			if (!body.response) {
+				callback(new Error("Malformed API response"));
+				return;
+			}
+
+			// Make sure at least some offers are well-formed. Apparently some offers can be empty just forever. Because Steam.
+			var allOffers = (body.response.trade_offers_sent || []).concat(body.response.trade_offers_received || []);
+			if (allOffers.length > 0 && (allOffers.every(Helpers.offerMalformed) || allOffers.some(Helpers.offerSuperMalformed))) {
+				callback(new Error("Data temporarily unavailable"));
+				return;
+			}
+
+			sentOffers = sentOffers.concat(body.response.trade_offers_sent || []);
+			receivedOffers = receivedOffers.concat(body.response.trade_offers_received || []);
+
+			options.cursor = body.response.next_cursor || 0;
+			if (typeof options.cursor == 'number' && options.cursor != 0) {
+				this.emit('debug', 'GetTradeOffers with cursor ' + options.cursor);
+				request();
+			} else {
+				finish();
+			}
+		});
+	};
+
+	var finish = () => {
 
 		//manager._digestDescriptions(body.response.descriptions);
 
 		// Let's check the asset cache and see if we have descriptions that match these items.
 		// If the necessary descriptions aren't in the asset cache, this will request them from the WebAPI and store
 		// them for future use.
-		Helpers.checkNeededDescriptions(this, (body.response.trade_offers_sent || []).concat(body.response.trade_offers_received || []), (err) => {
+		Helpers.checkNeededDescriptions(this, sentOffers.concat(receivedOffers), (err) => {
 			if (err) {
 				callback(new Error("Descriptions: " + err.message));
 				return;
 			}
 
-			var sent = (body.response.trade_offers_sent || []).map(data => Helpers.createOfferFromData(this, data));
-			var received = (body.response.trade_offers_received || []).map(data => Helpers.createOfferFromData(this, data));
+			var sent = sentOffers.map(data => Helpers.createOfferFromData(this, data));
+			var received = receivedOffers.map(data => Helpers.createOfferFromData(this, data));
 
 			callback(null, sent, received);
 			this.emit('offerList', filter, sent, received);
 		});
-	});
+	};
+
+	request();
 };

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -231,31 +231,24 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 				hasGlitchedOffer = true;
 				return;
 			}
-
+			changed = true;
 			if (offer.fromRealTimeTrade) {
 				// This is a real-time trade offer
 				if (!offers[offer.id] && (offer.state == ETradeOfferState.CreatedNeedsConfirmation || (offer.state == ETradeOfferState.Active && offer.confirmationMethod != EConfirmationMethod.None))) {
-					changed = true;
 					this.emit('realTimeTradeConfirmationRequired', offer);
 				} else if (offer.state == ETradeOfferState.Accepted && (!offers[offer.id] || (offers[offer.id] != offer.state))) {
-					changed = true;
 					this.emit('realTimeTradeCompleted', offer);
 				}
 			}
 
 			if (!offers[offer.id] && offer.state == ETradeOfferState.Active) {
-				changed = true;
 				this.emit('newOffer', offer);
 			} else if (offers[offer.id] && offer.state != offers[offer.id]) {
-				changed = true;
 				this.emit('receivedOfferChanged', offer, offers[offer.id]);
 			}
 
 			offers[offer.id] = offer.state;
-			if(!timestamps[offer.id] || timestamps[offer.id] != offer.created.getTime() / 1000) {
-				changed = true;
-				timestamps[offer.id] = offer.created.getTime() / 1000;
-			}
+			timestamps[offer.id] = offer.created.getTime() / 1000;
 		});
 
 		this.pollData.received = offers;

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -51,6 +51,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 	}
 
 	this.emit('debug', 'Doing trade offer poll since ' + offersSince + (fullUpdate ? ' (full update)' : ''));
+	var requestStart = Date.now();
 	this.getOffers(fullUpdate ? EOfferFilter.All : EOfferFilter.ActiveOnly, new Date(offersSince * 1000), (err, sent, received) => {
 		if (err) {
 			this.emit('debug', "Error getting trade offers for poll: " + err.message);
@@ -58,6 +59,8 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 			this._resetPollTimer();
 			return;
 		}
+
+		this.emit('debug', 'Trade offer poll succeeded in ' + (Date.now() - requestStart) + ' ms');
 
 		/*if (fullUpdate) {
 			// We can only purge stuff if this is a full update; otherwise, lack of an offer's presence doesn't mean Steam forgot about it

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -108,6 +108,8 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 			});
 		}*/
 
+		let changed = false;
+
 		var timestamps = this.pollData.timestamps || {};
 		var offers = this.pollData.sent || {};
 		var hasGlitchedOffer = false;
@@ -132,8 +134,10 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 					this.emit('unknownOfferSent', offer);
 					offers[offer.id] = offer.state;
 					timestamps[offer.id] = offer.created.getTime() / 1000;
+					changed = true;
 				}
 			} else if (offer.state != offers[offer.id]) {
+				changed = true;
 				if (!offer.isGlitched()) {
 					// We sent this offer, and it has now changed state
 					if (offer.fromRealTimeTrade && offer.state == ETradeOfferState.Accepted) {
@@ -162,6 +166,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 				}
 
 				if (cancelTime && (Date.now() - offer.updated.getTime() >= cancelTime)) {
+					changed = true;
 					offer.cancel((err) => {
 						if (!err) {
 							this.emit('sentOfferCanceled', offer, 'cancelTime');
@@ -182,6 +187,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 				}
 
 				if (pendingCancelTime && (Date.now() - offer.created.getTime() >= pendingCancelTime)) {
+					changed = true;
 					offer.cancel((err) => {
 						if (!err) {
 							this.emit('sentPendingOfferCanceled', offer);
@@ -208,6 +214,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 
 				// Make sure it's old enough
 				if (Date.now() - oldest.updated.getTime() >= this.cancelOfferCountMinAge) {
+					changed = true;
 					oldest.cancel((err) => {
 						if (!err) {
 							this.emit('sentOfferCanceled', oldest, 'cancelOfferCount');
@@ -229,20 +236,27 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 			if (offer.fromRealTimeTrade) {
 				// This is a real-time trade offer
 				if (!offers[offer.id] && (offer.state == ETradeOfferState.CreatedNeedsConfirmation || (offer.state == ETradeOfferState.Active && offer.confirmationMethod != EConfirmationMethod.None))) {
+					changed = true;
 					this.emit('realTimeTradeConfirmationRequired', offer);
 				} else if (offer.state == ETradeOfferState.Accepted && (!offers[offer.id] || (offers[offer.id] != offer.state))) {
+					changed = true;
 					this.emit('realTimeTradeCompleted', offer);
 				}
 			}
 
 			if (!offers[offer.id] && offer.state == ETradeOfferState.Active) {
+				changed = true;
 				this.emit('newOffer', offer);
 			} else if (offers[offer.id] && offer.state != offers[offer.id]) {
+				changed = true;
 				this.emit('receivedOfferChanged', offer, offers[offer.id]);
 			}
 
 			offers[offer.id] = offer.state;
-			timestamps[offer.id] = offer.created.getTime() / 1000;
+			if(!timestamps[offer.id] || timestamps[offer.id] != offer.created.getTime() / 1000) {
+				changed = true;
+				timestamps[offer.id] = offer.created.getTime() / 1000;
+			}
 		});
 
 		this.pollData.received = offers;
@@ -264,7 +278,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 		this.emit('pollSuccess');
 
 		// If something has changed, emit the event
-		if (!deepEqual(origPollData, this.pollData)) {
+		if (changed) {
 			this.emit('pollData', this.pollData);
 		}
 

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -59,8 +59,6 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 			return;
 		}
 
-		var origPollData = JSON.parse(JSON.stringify(this.pollData)); // deep clone
-
 		/*if (fullUpdate) {
 			// We can only purge stuff if this is a full update; otherwise, lack of an offer's presence doesn't mean Steam forgot about it
 			var trackedIds = sent.map(offerId).concat(received.map(offerId)); // OfferIDs that are active in Steam's memory

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -4,7 +4,6 @@ const TradeOfferManager = require('./index.js');
 const ETradeOfferState = TradeOfferManager.ETradeOfferState;
 const EOfferFilter = TradeOfferManager.EOfferFilter;
 const EConfirmationMethod = TradeOfferManager.EConfirmationMethod;
-const deepEqual = require('deep-equal');
 
 const minimumPollInterval = 1000;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,652 @@
+{
+  "name": "@tf2autobot/tradeoffer-manager",
+  "version": "2.11.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@doctormckay/stats-reporter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@doctormckay/stats-reporter/-/stats-reporter-1.0.5.tgz",
+      "integrity": "sha512-lCAuKW053zz91sKZZcGfOHxigBqn0Lo+/JvHBQq3XqzLJxn0YeZ5mJ96+PZto+PDCkgg+c/BX2Xo8DvAN44xLg=="
+    },
+    "@doctormckay/stdlib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.14.1.tgz",
+      "integrity": "sha512-jGuJydIo2JB6IgOkOPNRr6fTJH9IdJCGH9yfVoEWzBjH0ptn22KsvOuJW+BG96O1eI1jSQ5C5myZr5Rj4gZ+Qw=="
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "appdirectory": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/appdirectory/-/appdirectory-0.1.0.tgz",
+      "integrity": "sha1-62yBYyDnsqsW9e2ZfyjYIF31Y3U="
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "cheerio": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash.assignin": "^4.0.9",
+        "lodash.bind": "^4.1.4",
+        "lodash.defaults": "^4.0.1",
+        "lodash.filter": "^4.4.0",
+        "lodash.flatten": "^4.2.0",
+        "lodash.foreach": "^4.3.0",
+        "lodash.map": "^4.4.0",
+        "lodash.merge": "^4.4.0",
+        "lodash.pick": "^4.2.1",
+        "lodash.reduce": "^4.4.0",
+        "lodash.reject": "^4.4.0",
+        "lodash.some": "^4.4.0"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+    },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "file-manager": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/file-manager/-/file-manager-1.0.1.tgz",
+      "integrity": "sha1-yZySdeSoyNr13vFR9rUUBVIegXo=",
+      "requires": {
+        "async": "^1.4.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "image-size": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.8.3.tgz",
+      "integrity": "sha512-SMtq1AJ+aqHB45c3FsB4ERK0UCiA2d3H1uq8s+8T0Pf8A3W4teyBQyaFaktH6xvZqh+npwlKU7i4fJo0r7TYTg==",
+      "requires": {
+        "queue": "6.0.1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "languages": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/languages/-/languages-0.1.3.tgz",
+      "integrity": "sha1-8ZJzuw6Uas0t6xDAfHUO4Si91LA="
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.assignin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
+    },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+    },
+    "lodash.reject": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+    },
+    "mime-db": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+    },
+    "mime-types": {
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "requires": {
+        "mime-db": "1.47.0"
+      }
+    },
+    "node-bignumber": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-bignumber/-/node-bignumber-1.2.1.tgz",
+      "integrity": "sha1-JmyVUzUoOFOfZhyS5YYxvpeRfqU="
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "queue": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.1.tgz",
+      "integrity": "sha512-AJBQabRCCNr9ANq8v77RJEv73DPbn55cdTb+Giq4X0AVnNVZvMHlYp7XlQiN+1npCZj1DuSmaA2hYVUUDgxFDg==",
+      "requires": {
+        "inherits": "~2.0.3"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "steam-totp": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-1.5.0.tgz",
+      "integrity": "sha512-RMlBK5dFtgplDMYYGg/k80RqEntzBcl7C/0RF18fQh9+XPe/iEMsfKmIE+xj8I3hqJW1akANAC6gf+YpfZq52w==",
+      "requires": {
+        "@doctormckay/stats-reporter": "^1.0.0"
+      }
+    },
+    "steamcommunity": {
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/steamcommunity/-/steamcommunity-3.42.0.tgz",
+      "integrity": "sha512-nmIp/OoRXmOM66Tib+Gu9Q3G85I0NubkCijSa1PnV0OgTZHkeFqW1KxNyI64iO3jXpn7IOuOsglwwLKH6ZU60g==",
+      "requires": {
+        "async": "^2.6.3",
+        "cheerio": "0.22.0",
+        "image-size": "^0.8.2",
+        "node-bignumber": "^1.2.1",
+        "request": "^2.88.0",
+        "steam-totp": "^1.5.0",
+        "steamid": "^1.1.3",
+        "xml2js": "^0.4.22"
+      }
+    },
+    "steamid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/steamid/-/steamid-1.1.3.tgz",
+      "integrity": "sha512-t86YjtP1LtPt8D+TaIARm6PtC9tBnF1FhxQeLFs6ohG7vDUfQuy/M8II14rx1TTUkVuYoWHP/7DlvTtoCGULcw==",
+      "requires": {
+        "cuint": "^0.2.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tf2autobot/tradeoffer-manager",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tf2autobot/tradeoffer-manager",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "description": "A simple trade offers API for Steam",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tf2autobot/tradeoffer-manager",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "A simple trade offers API for Steam",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tf2autobot/tradeoffer-manager",
-  "version": "1.1.0",
+  "version": "2.10.0",
   "description": "A simple trade offers API for Steam",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tf2autobot/tradeoffer-manager",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple trade offers API for Steam",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "file-manager": "^1.0.1",
     "languages": "^0.1.3",
     "steamcommunity": "^3.43.1",
-    "steamid": "^1.1.0"
+    "steamid": "^2.0.0"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@tf2autobot/node-steam-tradeoffer-manager",
-  "version": "0.1.0",
+  "name": "@tf2autobot/tradeoffer-manager",
+  "version": "1.0.0",
   "description": "A simple trade offers API for Steam",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@doctormckay/stdlib": "^1.5.1",
     "appdirectory": "^0.1.0",
-    "async": "^3.2.0",
+    "async": "^2.6.0",
     "file-manager": "^2.0.0",
     "languages": "^0.1.3",
     "steamcommunity": "^3.33.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tf2autobot/tradeoffer-manager",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "A simple trade offers API for Steam",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-	"name": "steam-tradeoffer-manager",
-	"version": "2.10.2",
+	"name": "@TF2autobot/steam-tradeoffer-manager",
+	"version": "2.11",
 	"description": "A simple trade offers API for Steam",
 	"main": "./lib/index.js",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/DoctorMcKay/node-steam-tradeoffer-manager.git"
+		"url": "https://github.com/TF2Autobot/node-steam-tradeoffer-manager.git"
 	},
 	"keywords": [
 		"steam",
@@ -18,9 +18,9 @@
 	"author": "Alex Corn <mckay@doctormckay.com>",
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/issues"
+		"url": "https://github.com/TF2Autobot/node-steam-tradeoffer-manager/issues"
 	},
-	"homepage": "https://github.com/DoctorMcKay/node-steam-tradeoffer-manager",
+	"homepage": "https://github.com/TF2Autobot/node-steam-tradeoffer-manager",
 	"scripts": {
 		"update-resources": "node scripts/update-resources.js"
 	},

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@doctormckay/stdlib": "^1.5.1",
     "appdirectory": "^0.1.0",
-    "async": "^2.6.0",
-    "file-manager": "^1.0.1",
+    "async": "^3.2.0",
+    "file-manager": "^2.0.0",
     "languages": "^0.1.3",
     "steamcommunity": "^3.33.1",
     "steamid": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tf2autobot/tradeoffer-manager",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A simple trade offers API for Steam",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@doctormckay/stdlib": "^1.5.1",
     "appdirectory": "^0.1.0",
     "async": "^2.6.0",
-    "file-manager": "^2.0.0",
+    "file-manager": "^1.0.1",
     "languages": "^0.1.3",
     "steamcommunity": "^3.33.1",
     "steamid": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "async": "^2.6.0",
     "file-manager": "^1.0.1",
     "languages": "^0.1.3",
-    "steamcommunity": "^3.33.1",
+    "steamcommunity": "^3.43.1",
     "steamid": "^1.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,40 +1,44 @@
 {
-	"name": "@TF2autobot/steam-tradeoffer-manager",
-	"version": "2.11",
-	"description": "A simple trade offers API for Steam",
-	"main": "./lib/index.js",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/TF2Autobot/node-steam-tradeoffer-manager.git"
-	},
-	"keywords": [
-		"steam",
-		"trade",
-		"offers",
-		"tradeoffers",
-		"trading",
-		"trade"
-	],
-	"author": "Alex Corn <mckay@doctormckay.com>",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/TF2Autobot/node-steam-tradeoffer-manager/issues"
-	},
-	"homepage": "https://github.com/TF2Autobot/node-steam-tradeoffer-manager",
-	"scripts": {
-		"update-resources": "node scripts/update-resources.js"
-	},
-	"dependencies": {
-		"@doctormckay/stdlib": "^1.5.1",
-		"appdirectory": "^0.1.0",
-		"async": "^2.6.0",
-		"deep-equal": "^1.0.1",
-		"file-manager": "^1.0.1",
-		"languages": "^0.1.3",
-		"steamcommunity": "^3.33.1",
-		"steamid": "^1.1.0"
-	},
-	"engines": {
-		"node": ">=4.0.0"
-	}
+  "name": "@tf2autobot/node-steam-tradeoffer-manager",
+  "version": "0.1.0",
+  "description": "A simple trade offers API for Steam",
+  "main": "./lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TF2Autobot/node-steam-tradeoffer-manager.git"
+  },
+  "keywords": [
+    "steam",
+    "trade",
+    "offers",
+    "tradeoffers",
+    "trading",
+    "trade"
+  ],
+  "author": "Alex Corn <mckay@doctormckay.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/TF2Autobot/node-steam-tradeoffer-manager/issues"
+  },
+  "homepage": "https://github.com/TF2Autobot/node-steam-tradeoffer-manager",
+  "scripts": {
+    "update-resources": "node scripts/update-resources.js"
+  },
+  "dependencies": {
+    "@doctormckay/stdlib": "^1.5.1",
+    "appdirectory": "^0.1.0",
+    "async": "^2.6.0",
+    "file-manager": "^1.0.1",
+    "languages": "^0.1.3",
+    "steamcommunity": "^3.33.1",
+    "steamid": "^1.1.0"
+  },
+  "engines": {
+    "node": ">=4.0.0"
+  },
+  "directories": {
+    "example": "examples",
+    "lib": "lib"
+  },
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tf2autobot/tradeoffer-manager",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "A simple trade offers API for Steam",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tf2autobot/tradeoffer-manager",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A simple trade offers API for Steam",
   "main": "./lib/index.js",
   "repository": {


### PR DESCRIPTION
This pull request changes cancel and decline for tradeoffers, so that it uses steamcommunity instead of API, because the endpoints were removed.