### PR TITLE
Add getPartnerInventory method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -305,7 +305,6 @@ TradeOfferManager.prototype._getFromDisk = function(filenames, callback) {
 				"appid": appID,
 				"contextid": contextID,
 				"start": start,
-				"trading": 1,
 			},
 			"json": true
 		}, function(err, response, body) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -316,7 +316,7 @@ TradeOfferManager.prototype._getFromDisk = function(filenames, callback) {
 
 			if (!body || !body.success || !body.rgInventory || !body.rgDescriptions || !body.rgCurrency) {
 				if (body) {
-					callback(new Error(body.Error || "Malformed response"));
+					callback(new Error(body.Error || body.error || "Malformed response"));
 				} else {
 					callback(new Error("Malformed response"));
 				}

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ const EConfirmationMethod = TradeOfferManager.EConfirmationMethod = require('../
 const ETradeStatus = TradeOfferManager.ETradeStatus = require('../resources/ETradeStatus.js');
 
 const TradeOffer = require('./classes/TradeOffer.js');
+const CEconItem = require('steamcommunity/classes/CEconItem.js');
 
 require('util').inherits(TradeOfferManager, require('events').EventEmitter);
 
@@ -274,6 +275,85 @@ TradeOfferManager.prototype._getFromDisk = function(filenames, callback) {
 			callback(null, files);
 		}
 	});
+};
+
+/**
+ * Get the contents of a partner's inventory.
+ * @param {SteamID|string} partnerIDID - The partner's SteamID as a SteamID object or a string which can parse into one
+ * @param {int} appID - The Steam application ID of the game for which you want an inventory
+ * @param {int} contextID - The ID of the "context" within the game you want to retrieve
+ * @param {boolean} tradableOnly - true to get only tradable items and currencies
+ * @param {function} callback
+ */
+ TradeOfferManager.prototype.getPartnerInventory = function(partnerID, appID, contextID, tradableOnly, callback) {
+	var self = this;
+
+	if (typeof partnerID === 'string') {
+		partnerID = new SteamID(partnerID);
+	}
+
+	get([], []);
+
+	function get(inventory, currency, start) {
+		self._community.httpRequestGet({
+			"uri": `https://steamcommunity.com/tradeoffer/new/partnerinventory`,
+			"headers": {
+				"Referer": "https://steamcommunity.com/tradeoffer/new/"
+			},
+			"qs": {
+				"sessionid": self._community.getSessionID(),
+				"partner": partnerID.getSteamID64(),
+				"appid": appID,
+				"contextid": contextID,
+				"start": start,
+				"trading": tradableOnly ? 1 : undefined
+			},
+			"json": true
+		}, function(err, response, body) {
+			if (err) {
+				callback(err);
+				return;
+			}
+
+			if (!body || !body.success || !body.rgInventory || !body.rgDescriptions || !body.rgCurrency) {
+				if (body) {
+					callback(new Error(body.Error || "Malformed response"));
+				} else {
+					callback(new Error("Malformed response"));
+				}
+
+				return;
+			}
+
+			var i;
+			for (i in body.rgInventory) {
+				if (!body.rgInventory.hasOwnProperty(i)) {
+					continue;
+				}
+
+				inventory.push(new CEconItem(body.rgInventory[i], body.rgDescriptions, contextID));
+			}
+
+			for (i in body.rgCurrency) {
+				if (!body.rgCurrency.hasOwnProperty(i)) {
+					continue;
+				}
+
+				currency.push(new CEconItem(body.rgInventory[i], body.rgDescriptions, contextID));
+			}
+
+			if (body.more) {
+				var match = response.request.uri.href.match(/\/(profiles|id)\/([^\/]+)\//);
+				if(match) {
+					endpoint = "/" + match[1] + "/" + match[2];
+				}
+
+				get(inventory, currency, body.more_start);
+			} else {
+				callback(null, inventory, currency);
+			}
+		}, "tradeoffermanager");
+	}
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -282,10 +282,9 @@ TradeOfferManager.prototype._getFromDisk = function(filenames, callback) {
  * @param {SteamID|string} partnerID - The partner's SteamID as a SteamID object or a string which can parse into one
  * @param {int} appID - The Steam application ID of the game for which you want an inventory
  * @param {int} contextID - The ID of the "context" within the game you want to retrieve
- * @param {boolean} tradableOnly - true to get only tradable items and currencies
  * @param {function} callback
  */
- TradeOfferManager.prototype.getPartnerInventory = function(partnerID, appID, contextID, tradableOnly, callback) {
+ TradeOfferManager.prototype.getPartnerInventory = function(partnerID, appID, contextID, callback) {
 	var self = this;
 
 	if (typeof partnerID === 'string') {
@@ -306,7 +305,7 @@ TradeOfferManager.prototype._getFromDisk = function(filenames, callback) {
 				"appid": appID,
 				"contextid": contextID,
 				"start": start,
-				"trading": tradableOnly ? 1 : undefined
+				"trading": 1,
 			},
 			"json": true
 		}, function(err, response, body) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -343,11 +343,6 @@ TradeOfferManager.prototype._getFromDisk = function(filenames, callback) {
 			}
 
 			if (body.more) {
-				var match = response.request.uri.href.match(/\/(profiles|id)\/([^\/]+)\//);
-				if(match) {
-					endpoint = "/" + match[1] + "/" + match[2];
-				}
-
 				get(inventory, currency, body.more_start);
 			} else {
 				callback(null, inventory, currency);

--- a/lib/index.js
+++ b/lib/index.js
@@ -279,7 +279,7 @@ TradeOfferManager.prototype._getFromDisk = function(filenames, callback) {
 
 /**
  * Get the contents of a partner's inventory.
- * @param {SteamID|string} partnerIDID - The partner's SteamID as a SteamID object or a string which can parse into one
+ * @param {SteamID|string} partnerID - The partner's SteamID as a SteamID object or a string which can parse into one
  * @param {int} appID - The Steam application ID of the game for which you want an inventory
  * @param {int} contextID - The ID of the "context" within the game you want to retrieve
  * @param {boolean} tradableOnly - true to get only tradable items and currencies


### PR DESCRIPTION
I am adding this method as it is not affected by the new rate limit imposed by steam in the last update.

All other methods of obtaining an inventory have been affected and this is the only decent way to obtain one now.