### PR TITLE
Added 'br' language for Brazilian Portuguese, since 'languages' package doesn't handle it

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,9 @@ function TradeOfferManager(options) {
 		} else if (this._language == 'tzh') {
 			this._language = 'zh';
 			this._languageName = 'tchinese';
+		} else if (this._language == 'br') {
+			this._language = 'pt-BR';
+			this._languageName = 'brazilian';
 		} else {
 			var lang = require('languages').getLanguageInfo(this._language);
 			if (!lang.name) {


### PR DESCRIPTION
These changes fixed this issue for me:
https://github.com/DoctorMcKay/node-steam-tradeoffer-manager/issues/331