### PR TITLE
Add minimumPoolInterval option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,6 +67,7 @@ function TradeOfferManager(options) {
 	}
 
 	this.pollInterval = options.pollInterval || 30000;
+	this.minimumPollInterval = options.minimumPollInterval || 1000;
 	this.cancelTime = options.cancelTime;
 	this.pendingCancelTime = options.pendingCancelTime;
 	this.cancelOfferCount = options.cancelOfferCount;

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -6,8 +6,6 @@ const EOfferFilter = TradeOfferManager.EOfferFilter;
 const EConfirmationMethod = TradeOfferManager.EConfirmationMethod;
 const deepEqual = require('deep-equal');
 
-const minimumPollInterval = 1000;
-
 /*
  * pollData is an object which has the following structure:
  *  - `offersSince` is the STANDARD unix time (Math.floor(Date.now() / 1000)) of the last known offer change
@@ -27,10 +25,10 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 
 	const timeSinceLastPoll = Date.now() - this._lastPoll;
 
-	if (timeSinceLastPoll < minimumPollInterval) {
+	if (timeSinceLastPoll < this.minimumPollInterval) {
 		// We last polled less than a second ago... we shouldn't spam the API
 		// Reset the timer to poll minimumPollInterval after the last one
-		this._resetPollTimer(minimumPollInterval - timeSinceLastPoll);
+		this._resetPollTimer(this.minimumPollInterval - timeSinceLastPoll);
 		return;
 	}
 
@@ -276,7 +274,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 };
 
 TradeOfferManager.prototype._resetPollTimer = function(time) {
-	if (time || this.pollInterval >= minimumPollInterval) {
+	if (time || this.pollInterval >= this.minimumPollInterval) {
 		clearTimeout(this._pollTimer);
 		this._pollTimer = setTimeout(this.doPoll.bind(this), time || this.pollInterval);
 	}


### PR DESCRIPTION
For some reasons will be cool to see that option. It can guarantee that we would not make api calls often, even if we provide steam-user instance.