### PR TITLE
Add option to change full update interval in polling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,6 +67,7 @@ function TradeOfferManager(options) {
 	}
 
 	this.pollInterval = options.pollInterval || 30000;
+	this.pollFullUpdateInterval = options.pollFullUpdateInterval || 120000;
 	this.cancelTime = options.cancelTime;
 	this.pendingCancelTime = options.pendingCancelTime;
 	this.cancelOfferCount = options.cancelOfferCount;

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -45,7 +45,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 	}
 
 	var fullUpdate = false;
-	if (Date.now() - this._lastPollFullUpdate >= 120000 || doFullUpdate) {
+	if (Date.now() - this._lastPollFullUpdate >= this.pollFullUpdateInterval || doFullUpdate) {
 		fullUpdate = true;
 		this._lastPollFullUpdate = Date.now();
 		offersSince = 1;


### PR DESCRIPTION
Allow users to configure the previously hard coded 2 minute interval for full updates in polling. Keeping the default value at 2 minutes.