### PR TITLE
fix: notify session expired on 403

### DIFF
--- a/lib/webapi.js
+++ b/lib/webapi.js
@@ -36,16 +36,13 @@ TradeOfferManager.prototype._apiCall = function(httpMethod, method, version, inp
 	options[httpMethod == 'GET' ? 'qs' : 'form'] = input;
 
 	this._community.httpRequest(options, (err, response, body) => {
-		if (err) {
-			err.body = body;
-			callback(err);
-			return;
+		var error = err;
+
+		if (response.statusCode != 200 && !error) {
+			error = new Error('HTTP error ' + response.statusCode);
 		}
 
-		var error;
-
-		if (response.statusCode != 200) {
-			error = new Error('HTTP error ' + response.statusCode);
+		if (error) {
 			error.body = body;
 
 			if (typeof response.body === 'string' && response.body.indexOf('Access is denied') >= 0) {


### PR DESCRIPTION
Fixes #350 

Tested locally by replacing `input.access_key` at runtime with debugger. The session expired event was called properly