### PR TITLE
fix(#356): doPoll after setCookies only if polling is enabled

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -249,7 +249,9 @@ TradeOfferManager.prototype.setCookies = function(cookies, familyViewPin, callba
 		}
 
 		clearTimeout(this._pollTimer);
-		this.doPoll();
+
+		if (this.pollInterval >= 0) 
+			this.doPoll();
 
 		callback && callback();
 	};


### PR DESCRIPTION
Fixes #356

Checks if polling is enabled before calling `doPoll` in `setCookies`