### PR TITLE
fix: dont use asset cache for items without an instanceid

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -40,7 +40,7 @@ TradeOfferManager.prototype._mapItemsToDescriptions = function(appid, contextid,
 
 		var key = `${item.appid}_${item.classid}_${item.instanceid || '0'}`;
 		var entry = cache.get(key);
-		if (!entry) {
+		if (!entry || !item.instanceid) {
 			// This item isn't in our description cache
 			return new EconItem(item);
 		}


### PR DESCRIPTION
This fix has solved the "0" assetid bug in my experience. I noticed that assetids are defined in rawJson but are set 0 when the items instanceid is 0, because it retrieves the 0 assetid from asset cache. I have made a quick fix by just bypassing asset cache for items without an instanceid, but not sure if its the best solution. I figure its safer than using all the other values for the asset from the asset cache except assetid and contextid but not sure. Definitely needs more testing