### PR TITLE
Feat: Added asset properties to loadPartnerInventory response

### DIFF
--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -197,6 +197,10 @@ TradeOffer.prototype.loadPartnerInventory = function(appid, contextid, callback)
 					item[j] = description[j];
 				}
 
+				if (item.id || item.assetid) {
+					item.assetProperties = (body.rgAssetProperties || {})[item.id || item.assetid] || [];
+				}
+
 				item.appid = appid;
 				item.contextid = contextid;
 


### PR DESCRIPTION
### Why
Valves update regarding the inspect URLs require the `propertyid` 6.

### How
- Mapped `rgAssetProperties` entries onto `EconItem` instances returned by `loadPartnerInventory()`

### Notes
`loadPartnerInventory()` is marked as deprecated, but as far as I know it is still the only available way to retrieve tradable items with a `<10d` viewable restriction from public partner inventories. This change is intentionally scoped to that inventory path for that reason.